### PR TITLE
Add basic clients screen and dashboard wiring

### DIFF
--- a/lib/Clientes/clientes.dart
+++ b/lib/Clientes/clientes.dart
@@ -1,0 +1,146 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+
+class ClientesScreen extends StatefulWidget {
+  const ClientesScreen({super.key});
+
+  @override
+  State<ClientesScreen> createState() => _ClientesScreenState();
+}
+
+class _ClientesScreenState extends State<ClientesScreen> {
+  String? businessId;
+  bool isLoading = true;
+  String? error;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadBusinessForCurrentUser();
+  }
+
+  Future<void> _loadBusinessForCurrentUser() async {
+    try {
+      final user = FirebaseAuth.instance.currentUser;
+      if (user == null) {
+        setState(() {
+          error = 'Usuario no autenticado';
+          isLoading = false;
+        });
+        return;
+      }
+
+      final globalUserDoc = await FirebaseFirestore.instance
+          .collection('usuarios')
+          .doc(user.uid)
+          .get();
+      String? bizId;
+      if (globalUserDoc.exists) {
+        bizId = globalUserDoc.data()!['negocio_id'] as String?;
+      }
+      if (bizId == null) {
+        final q = await FirebaseFirestore.instance
+            .collection('negocios')
+            .where('owner_uid', isEqualTo: user.uid)
+            .where('activo', isEqualTo: true)
+            .limit(1)
+            .get();
+        if (q.docs.isNotEmpty) bizId = q.docs.first.id;
+      }
+      if (bizId == null) {
+        setState(() {
+          error = 'No se encontró un negocio activo para este usuario';
+          isLoading = false;
+        });
+        return;
+      }
+      setState(() {
+        businessId = bizId;
+        isLoading = false;
+      });
+    } catch (e) {
+      setState(() {
+        error = 'Error cargando negocio: $e';
+        isLoading = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (isLoading) {
+      return Scaffold(
+        backgroundColor: Colors.grey[50],
+        appBar: AppBar(
+          title: const Text('Clientes'),
+          backgroundColor: Colors.white,
+          foregroundColor: Colors.black,
+          elevation: 0,
+        ),
+        body: const Center(child: CircularProgressIndicator()),
+      );
+    }
+    if (error != null) {
+      return Scaffold(
+        backgroundColor: Colors.grey[50],
+        appBar: AppBar(
+          title: const Text('Clientes'),
+          backgroundColor: Colors.white,
+          foregroundColor: Colors.black,
+          elevation: 0,
+        ),
+        body: Center(child: Text(error!)),
+      );
+    }
+
+    final clientsRef = FirebaseFirestore.instance
+        .collection('negocios')
+        .doc(businessId)
+        .collection('clientes')
+        .orderBy('createdAt', descending: true);
+
+    return Scaffold(
+      backgroundColor: Colors.grey[50],
+      appBar: AppBar(
+        title: const Text(
+          'Clientes',
+          style: TextStyle(fontSize: 20, fontWeight: FontWeight.w600),
+        ),
+        backgroundColor: Colors.white,
+        foregroundColor: Colors.black,
+        elevation: 0,
+      ),
+      body: StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
+        stream: clientsRef.snapshots(),
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (snapshot.hasError) {
+            return Center(child: Text('Error: ${snapshot.error}'));
+          }
+          final docs = snapshot.data?.docs ?? [];
+          if (docs.isEmpty) {
+            return const Center(child: Text('No hay clientes registrados'));
+          }
+          return ListView.separated(
+            itemCount: docs.length,
+            separatorBuilder: (_, __) => const Divider(height: 1),
+            itemBuilder: (context, index) {
+              final data = docs[index].data();
+              final name = data['nombre'] ?? 'Sin nombre';
+              final email = data['email'] ?? '';
+              final phone = data['telefono'] ?? '';
+              return ListTile(
+                title: Text(name),
+                subtitle: Text(email.isNotEmpty ? email : phone),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}
+

--- a/lib/Panel de control/dashboardscreen.dart
+++ b/lib/Panel de control/dashboardscreen.dart
@@ -10,6 +10,8 @@ import 'package:rapiven_admin_panel/Panel%20de%20control/estadisticasscreen.dart
 import 'package:rapiven_admin_panel/Punto%20de%20Venta%20(TPV)/puntodeventa.dart';
 import 'package:rapiven_admin_panel/Reservas/reservas.dart';
 import 'package:rapiven_admin_panel/Clientes/clientes.dart';
+import 'package:rapiven_admin_panel/Pedidos/tdc.dart';
+import 'package:rapiven_admin_panel/Pedidos/pedidos.dart';
 
 class DashboardScreen extends StatefulWidget {
   const DashboardScreen({super.key});
@@ -257,6 +259,10 @@ class _DashboardScreenState extends State<DashboardScreen> {
                     return const ReservationsScreen();
                   case 'Punto de Venta':
                     return const PuntoVentaScreen();
+                  case 'TDC':
+                    return const TdcScreen();
+                  case 'Pedidos':
+                    return const PedidosScreen();
                   case 'Clientes':
                     return const ClientesScreen();
                   // Puedes agregar más pantallas aquí

--- a/lib/Panel de control/dashboardscreen.dart
+++ b/lib/Panel de control/dashboardscreen.dart
@@ -6,10 +6,10 @@ import 'package:rapiven_admin_panel/Menu/grupodemoficadores.dart';
 import 'package:rapiven_admin_panel/Menu/menus.dart';
 import 'package:rapiven_admin_panel/Menu/modificadoresdearticulos.dart';
 import 'package:rapiven_admin_panel/Mesas/mesas.dart';
-import 'package:rapiven_admin_panel/Mesas/zonas.dart';
 import 'package:rapiven_admin_panel/Panel%20de%20control/estadisticasscreen.dart';
 import 'package:rapiven_admin_panel/Punto%20de%20Venta%20(TPV)/puntodeventa.dart';
 import 'package:rapiven_admin_panel/Reservas/reservas.dart';
+import 'package:rapiven_admin_panel/Clientes/clientes.dart';
 
 class DashboardScreen extends StatefulWidget {
   const DashboardScreen({super.key});
@@ -257,6 +257,8 @@ class _DashboardScreenState extends State<DashboardScreen> {
                     return const ReservationsScreen();
                   case 'Punto de Venta':
                     return const PuntoVentaScreen();
+                  case 'Clientes':
+                    return const ClientesScreen();
                   // Puedes agregar más pantallas aquí
                   default:
                     return Padding(

--- a/lib/Pedidos/pedidos.dart
+++ b/lib/Pedidos/pedidos.dart
@@ -1,0 +1,146 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+
+class PedidosScreen extends StatefulWidget {
+  const PedidosScreen({super.key});
+
+  @override
+  State<PedidosScreen> createState() => _PedidosScreenState();
+}
+
+class _PedidosScreenState extends State<PedidosScreen> {
+  String? businessId;
+  bool isLoading = true;
+  String? error;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadBusinessForCurrentUser();
+  }
+
+  Future<void> _loadBusinessForCurrentUser() async {
+    try {
+      final user = FirebaseAuth.instance.currentUser;
+      if (user == null) {
+        setState(() {
+          error = 'Usuario no autenticado';
+          isLoading = false;
+        });
+        return;
+      }
+
+      final globalUserDoc = await FirebaseFirestore.instance
+          .collection('usuarios')
+          .doc(user.uid)
+          .get();
+      String? bizId;
+      if (globalUserDoc.exists) {
+        bizId = globalUserDoc.data()!['negocio_id'] as String?;
+      }
+      if (bizId == null) {
+        final q = await FirebaseFirestore.instance
+            .collection('negocios')
+            .where('owner_uid', isEqualTo: user.uid)
+            .where('activo', isEqualTo: true)
+            .limit(1)
+            .get();
+        if (q.docs.isNotEmpty) bizId = q.docs.first.id;
+      }
+      if (bizId == null) {
+        setState(() {
+          error = 'No se encontró un negocio activo para este usuario';
+          isLoading = false;
+        });
+        return;
+      }
+      setState(() {
+        businessId = bizId;
+        isLoading = false;
+      });
+    } catch (e) {
+      setState(() {
+        error = 'Error cargando negocio: $e';
+        isLoading = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (isLoading) {
+      return Scaffold(
+        backgroundColor: Colors.grey[50],
+        appBar: AppBar(
+          title: const Text('Pedidos'),
+          backgroundColor: Colors.white,
+          foregroundColor: Colors.black,
+          elevation: 0,
+        ),
+        body: const Center(child: CircularProgressIndicator()),
+      );
+    }
+    if (error != null) {
+      return Scaffold(
+        backgroundColor: Colors.grey[50],
+        appBar: AppBar(
+          title: const Text('Pedidos'),
+          backgroundColor: Colors.white,
+          foregroundColor: Colors.black,
+          elevation: 0,
+        ),
+        body: Center(child: Text(error!)),
+      );
+    }
+
+    final ordersRef = FirebaseFirestore.instance
+        .collection('negocios')
+        .doc(businessId)
+        .collection('pedidos')
+        .orderBy('createdAt', descending: true);
+
+    return Scaffold(
+      backgroundColor: Colors.grey[50],
+      appBar: AppBar(
+        title: const Text(
+          'Pedidos',
+          style: TextStyle(fontSize: 20, fontWeight: FontWeight.w600),
+        ),
+        backgroundColor: Colors.white,
+        foregroundColor: Colors.black,
+        elevation: 0,
+      ),
+      body: StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
+        stream: ordersRef.snapshots(),
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (snapshot.hasError) {
+            return Center(child: Text('Error: ${snapshot.error}'));
+          }
+          final docs = snapshot.data?.docs ?? [];
+          if (docs.isEmpty) {
+            return const Center(child: Text('No hay pedidos'));
+          }
+          return ListView.separated(
+            itemCount: docs.length,
+            separatorBuilder: (_, __) => const Divider(height: 1),
+            itemBuilder: (context, index) {
+              final data = docs[index].data();
+              final numero = data['numero']?.toString() ?? 'Sin número';
+              final estado = data['estado'] ?? '';
+              final total = data['total']?.toString() ?? '';
+              return ListTile(
+                title: Text('Pedido $numero'),
+                subtitle: Text('Estado: $estado - Total: $total'),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}
+

--- a/lib/Pedidos/tdc.dart
+++ b/lib/Pedidos/tdc.dart
@@ -1,0 +1,146 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+
+class TdcScreen extends StatefulWidget {
+  const TdcScreen({super.key});
+
+  @override
+  State<TdcScreen> createState() => _TdcScreenState();
+}
+
+class _TdcScreenState extends State<TdcScreen> {
+  String? businessId;
+  bool isLoading = true;
+  String? error;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadBusinessForCurrentUser();
+  }
+
+  Future<void> _loadBusinessForCurrentUser() async {
+    try {
+      final user = FirebaseAuth.instance.currentUser;
+      if (user == null) {
+        setState(() {
+          error = 'Usuario no autenticado';
+          isLoading = false;
+        });
+        return;
+      }
+
+      final globalUserDoc = await FirebaseFirestore.instance
+          .collection('usuarios')
+          .doc(user.uid)
+          .get();
+      String? bizId;
+      if (globalUserDoc.exists) {
+        bizId = globalUserDoc.data()!['negocio_id'] as String?;
+      }
+      if (bizId == null) {
+        final q = await FirebaseFirestore.instance
+            .collection('negocios')
+            .where('owner_uid', isEqualTo: user.uid)
+            .where('activo', isEqualTo: true)
+            .limit(1)
+            .get();
+        if (q.docs.isNotEmpty) bizId = q.docs.first.id;
+      }
+      if (bizId == null) {
+        setState(() {
+          error = 'No se encontró un negocio activo para este usuario';
+          isLoading = false;
+        });
+        return;
+      }
+      setState(() {
+        businessId = bizId;
+        isLoading = false;
+      });
+    } catch (e) {
+      setState(() {
+        error = 'Error cargando negocio: $e';
+        isLoading = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (isLoading) {
+      return Scaffold(
+        backgroundColor: Colors.grey[50],
+        appBar: AppBar(
+          title: const Text('TDC'),
+          backgroundColor: Colors.white,
+          foregroundColor: Colors.black,
+          elevation: 0,
+        ),
+        body: const Center(child: CircularProgressIndicator()),
+      );
+    }
+    if (error != null) {
+      return Scaffold(
+        backgroundColor: Colors.grey[50],
+        appBar: AppBar(
+          title: const Text('TDC'),
+          backgroundColor: Colors.white,
+          foregroundColor: Colors.black,
+          elevation: 0,
+        ),
+        body: Center(child: Text(error!)),
+      );
+    }
+
+    final ordersRef = FirebaseFirestore.instance
+        .collection('negocios')
+        .doc(businessId)
+        .collection('pedidos')
+        .where('estado', isEqualTo: 'cocina')
+        .orderBy('createdAt', descending: true);
+
+    return Scaffold(
+      backgroundColor: Colors.grey[50],
+      appBar: AppBar(
+        title: const Text(
+          'Tiempo de cocina',
+          style: TextStyle(fontSize: 20, fontWeight: FontWeight.w600),
+        ),
+        backgroundColor: Colors.white,
+        foregroundColor: Colors.black,
+        elevation: 0,
+      ),
+      body: StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
+        stream: ordersRef.snapshots(),
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (snapshot.hasError) {
+            return Center(child: Text('Error: ${snapshot.error}'));
+          }
+          final docs = snapshot.data?.docs ?? [];
+          if (docs.isEmpty) {
+            return const Center(child: Text('No hay pedidos en cocina'));
+          }
+          return ListView.separated(
+            itemCount: docs.length,
+            separatorBuilder: (_, __) => const Divider(height: 1),
+            itemBuilder: (context, index) {
+              final data = docs[index].data();
+              final numero = data['numero']?.toString() ?? 'Sin número';
+              final estado = data['estado'] ?? '';
+              return ListTile(
+                title: Text('Pedido $numero'),
+                subtitle: Text('Estado: $estado'),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- add ClientesScreen to list customers from Firestore
- wire Clients screen into dashboard navigation

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68952535fffc8327a2ff28b51f5f7c76